### PR TITLE
fix: nested structs

### DIFF
--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -6,6 +6,7 @@
   (struct)
   (parameters)
   (tuple_type)
+  (struct_type)
   (call_expression)
   (switch_case)
 ] @indent.begin
@@ -24,6 +25,7 @@
 (union_declaration "}" @indent.branch @indent.end)
 (struct_declaration "}" @indent.branch @indent.end)
 (struct "}" @indent.branch @indent.end)
+(struct_type "}" @indent.branch @indent.end)
 
 [
   (comment)


### PR DESCRIPTION
previous behavior:

```odin
Many_Structs :: struct {
    a: struct { b: i32 },
    b: struct {
    x: i32,
    y: struct {
    z: i32,
    },
    },
}
```

With this commit:
```odin
Many_Structs :: struct {
    a: struct { b: i32 },
    b: struct {
        x: i32,
        y: struct {
            z: i32,
	},
    },
}
```

The commit just makes structs inside another structs also get indented.