### PR TITLE
feat: add support for empty struct literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -839,6 +839,7 @@ module.exports = grammar({
       $.boolean,
       $.nil,
       $.uninitialized,
+      $.empty_struct_literal,
     )),
 
     struct: $ => seq(
@@ -854,6 +855,14 @@ module.exports = grammar({
       )),
       '}',
     ),
+
+    empty_struct_literal: $ => prec(1, seq(
+      'struct',
+      '{',
+      '}',
+      '{',
+      '}'
+    )),
 
     map: $ => seq(
       'map',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "odin",
   "word": "identifier",
   "rules": {
@@ -6778,6 +6777,10 @@
           {
             "type": "SYMBOL",
             "name": "uninitialized"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "empty_struct_literal"
           }
         ]
       }
@@ -6975,6 +6978,35 @@
           "value": "}"
         }
       ]
+    },
+    "empty_struct_literal": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "struct"
+          },
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+          },
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+          }
+        ]
+      }
     },
     "map": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -276,6 +276,10 @@
         "named": true
       },
       {
+        "type": "empty_struct_literal",
+        "named": true
+      },
+      {
         "type": "float",
         "named": true
       },
@@ -1287,6 +1291,11 @@
     }
   },
   {
+    "type": "empty_struct_literal",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "empty_type",
     "named": true,
     "fields": {}
@@ -1764,6 +1773,11 @@
     }
   },
   {
+    "type": "nil",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "or_break_expression",
     "named": true,
     "fields": {},
@@ -2187,7 +2201,6 @@
   {
     "type": "source_file",
     "named": true,
-    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -3292,7 +3305,7 @@
   },
   {
     "type": "nil",
-    "named": true
+    "named": false
   },
   {
     "type": "not_in",


### PR DESCRIPTION
Similarly to `go`, odin allows for empty struct literal values, eg

```odin
foo := struct{}{}
bar: map[int]struct{}
bar[0] = struct{}{}
```

Currently the grammar does not understand these and will cause issues if you try to use them.

This works well for me when working on `ols`.

I'm not very familiar with tree sitter parsers so I'm not sure if this is all the files I should commit, there were also some small changes within the `src/tree_sitter/*.h` files and the `package.json` file. Let me know if I should be including those as well.